### PR TITLE
Enable support for VirtIO-GL

### DIFF
--- a/tasks/enable-iommu.yaml
+++ b/tasks/enable-iommu.yaml
@@ -26,3 +26,11 @@
   notify:
     - Update initramfs
     - Reboot host
+
+- name: Enable VirtIO-GL support
+  ansible.builtin.apt:
+    package:
+      - libgl1
+      - libegl1
+    state: present
+  become: true


### PR DESCRIPTION
Install the required libraries to enable support for VirtIO-GL (VirGL GPU) display.