### PR TITLE
Network configuration improvements

### DIFF
--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -16,3 +16,8 @@
   with_items:
     - iscsid
     - open-iscsi
+
+- name: Restart network interfaces
+  ansible.builtin.systemd_service:
+    name: networking
+    state: restarted

--- a/tasks/config-network.yaml
+++ b/tasks/config-network.yaml
@@ -8,7 +8,7 @@
     group: root
     mode: 0644
   become: true
-  notify: Reboot host
+  notify: Restart network interfaces
 # check network configuration template
 
 - name: Configure network interface names

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -6,7 +6,29 @@ auto lo
 iface lo inet loopback
 
 {% for interface in pve__network_interfaces %}
+{% if interface is string %}
 iface {{ interface }} inet manual
+{% else %}
+{% if interface.auto is defined and interface.auto %}
+auto {{ interface.name }}
+{% endif %}
+{% if interface.allow is defined %}
+allow-{{ interface.allow }} {{ interface.name }}
+{% endif %}
+{% if interface.address is defined %}
+auto {{ interface.name }}
+iface {{ interface.name }} inet static
+  address {{ interface.address }}
+{% if interface.gateway is defined %}
+  gateway {{ interface.gateway }}
+{% endif %}
+{% else %}
+iface {{ interface.name }} inet manual
+{% endif %}
+{% if interface.description is defined %}
+#{{ interface.description }}
+{% endif %}
+{% endif %}
 
 {% endfor %}
 {% for bridge in pve__network_bridges %}

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -32,3 +32,6 @@ iface {{ bridge.name }} inet manual
 {% endif %}
 
 {% endfor %}
+
+# Add support for Proxmox SDN
+source /etc/network/interfaces.d/*

--- a/templates/link.j2
+++ b/templates/link.j2
@@ -1,5 +1,10 @@
- [Match]
- MACAddress={{ item.mac_address }}
+[Match]
+{% if item.mac_address is defined %}
+MACAddress={{ item.mac_address }}
+{% elif item.driver is defined %}
+Driver={{ item.driver }}
+{% endif %}
 
- [Link]
- Name={{ item.interface_name }}
+[Link]
+Name={{ item.interface_name }}
+MACAddressPolicy=persistent


### PR DESCRIPTION
- Hosts don't need to reboot to apply network configurations. A simple
restart on the networking service can handle it.

- For the Proxmox SDN configuration to work we need to include all the
files under the `/etc/network/interfaces.d/*`.
Source: https://pve.proxmox.com/pve-docs/chapter-pvesdn.html#_sdn_core

- Allow configuration of non-bridged interfaces as VLANs or regular
interfaces on the `/etc/network/interfaces` file.

- Add a property to match a driver for the persistent network naming
configuration. Also, it sets the MACAddressPolicy as `persistent` for all
the configured links. This will do nothing on ethernet adaptors that
already have a persistent MAC Address but will ensure that the cheap
ones will not get a different MAC Address on each system boot (for the
current system).