### PR TITLE
Standardize variable names

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,8 +1,8 @@
 ---
-pve__force_reboot: false
-pve__enterprise: false
-pve__iommu_passthrough: false
-pve__admin_group: Administrators
-pve__admin_user: admin@pve
-pve__audit_group: Auditors
-pve__audit_user: audit@pve
+pve_force_reboot: false
+pve_enterprise: false
+pve_iommu_passthrough: false
+pve_admin_group: Administrators
+pve_admin_user: admin@pve
+pve_audit_group: Auditors
+pve_audit_user: audit@pve

--- a/tasks/config-cluster.yaml
+++ b/tasks/config-cluster.yaml
@@ -1,59 +1,59 @@
 ---
 - name: Verify if cluster exists
   ansible.builtin.command: /usr/bin/pvecm status
-  register: pve_cluster_status
+  register: pve__cluster_status
   check_mode: no
   changed_when: false
   ignore_errors: true
   become: true
-  when: pve__cluster_master is defined
+  when: pve_cluster_master is defined
 
 - name: Create Proxmox cluster
   become: true
-  when: pve__cluster_master is defined and pve__cluster_master not in pve_cluster_status.stdout
+  when: pve_cluster_master is defined and pve_cluster_master not in pve__cluster_status.stdout
   block:
     - name: Create cluster (auto link discover)
-      ansible.builtin.command: /usr/bin/pvecm create {{ pve__cluster_master }}
-      when: pve__cluster_link is not defined
+      ansible.builtin.command: /usr/bin/pvecm create {{ pve_cluster_master }}
+      when: pve_cluster_link is not defined
 
     - name: Create cluster (manual link0)
-      ansible.builtin.command: /usr/bin/pvecm create {{ pve__cluster_master }} --link0 {{ pve__cluster_link }}
-      when: pve__cluster_link is defined
+      ansible.builtin.command: /usr/bin/pvecm create {{ pve_cluster_master }} --link0 {{ pve_cluster_link }}
+      when: pve_cluster_link is defined
 
 - name: Verify cluster membership
   ansible.builtin.command: /usr/bin/pvecm nodes
-  register: pve_cluster_nodes
-  failed_when: pve_cluster_nodes.rc != 0 and pve_cluster_nodes.rc != 2
+  register: pve__cluster_nodes
+  failed_when: pve__cluster_nodes.rc != 0 and pve__cluster_nodes.rc != 2
   check_mode: no
   changed_when: false
   ignore_errors: true
   become: true
-  when: pve__cluster_join is defined
+  when: pve_cluster_join is defined
 
 - name: Add Proxmox node to the cluster
   become: true
-  when: pve__cluster_join is defined and (pve_cluster_nodes.rc == 2 or pve__cluster_node not in pve_cluster_nodes.stdout)
+  when: pve_cluster_join is defined and (pve__cluster_nodes.rc == 2 or pve_cluster_node not in pve__cluster_nodes.stdout)
   block:
     - name: Add node using (auto link discover)
-      ansible.builtin.command: /usr/bin/pvecm add {{ pve__cluster_join }} --use_ssh
-      when: pve__cluster_link is not defined
+      ansible.builtin.command: /usr/bin/pvecm add {{ pve_cluster_join }} --use_ssh
+      when: pve_cluster_link is not defined
 
     - name: Add node to the cluster (manual link0)
-      ansible.builtin.command: /usr/bin/pvecm add {{ pve__cluster_join }} --link0 {{ pve__cluster_link }} --use_ssh
-      when: pve__cluster_link is defined
+      ansible.builtin.command: /usr/bin/pvecm add {{ pve_cluster_join }} --link0 {{ pve_cluster_link }} --use_ssh
+      when: pve_cluster_link is defined
 
 - name: Configure HA shutdown policy
   ansible.builtin.lineinfile:
     path: /etc/pve/datacenter.cfg
     regexp: "^ha:"
-    line: "ha: shutdown_policy={{ pve__cluster_ha_shutdown_policy }}"
+    line: "ha: shutdown_policy={{ pve_cluster_ha_shutdown_policy }}"
     state: present
-  when: pve__cluster_ha_shutdown_policy is defined
+  when: pve_cluster_ha_shutdown_policy is defined
 
 - name: Configure migration network
   ansible.builtin.lineinfile:
     path: /etc/pve/datacenter.cfg
     regexp: "^migration:"
-    line: "migration: network={{ pve__cluster_migration_network }},type=secure"
+    line: "migration: network={{ pve_cluster_migration_network }},type=secure"
     state: present
-  when: pve__cluster_migration_network is defined
+  when: pve_cluster_migration_network is defined

--- a/tasks/config-network.yaml
+++ b/tasks/config-network.yaml
@@ -19,8 +19,8 @@
     group: root
     mode: 0644
   with_items:
-    - "{{ pve__network_interface_alias }}"
-  when: pve__network_interface_alias is defined
+    - "{{ pve_network_interface_alias }}"
+  when: pve_network_interface_alias is defined
   become: true
   notify: Reboot host
 # check interface name template

--- a/tasks/config-pve-repos.yaml
+++ b/tasks/config-pve-repos.yaml
@@ -19,8 +19,7 @@
     update_cache: true
     filename: pve-no-subscription
   become: true
-  when:
-    - not pve__enterprise
+  when: not pve_enterprise
 
 - name: Add enterprise repository
   ansible.builtin.apt_repository:
@@ -29,6 +28,4 @@
     update_cache: true
     filename: pve-enterprise
   become: true
-  when:
-    - pve__enterprise
-
+  when: pve_enterprise

--- a/tasks/config-storage.yaml
+++ b/tasks/config-storage.yaml
@@ -1,7 +1,7 @@
 ---
-- name: Verify if storage exists
+- name: Check for the existing storages
   ansible.builtin.command: /usr/sbin/pvesm status
-  register: pve_storage_list
+  register: pve__storage_status
   check_mode: no
   changed_when: false
   become: true
@@ -14,9 +14,9 @@
     --password {{ item.password }}
     --content {{ item.content | default("images") }}
     --shared {{ item.shared | default(true) }}
-  with_items: "{{ pve__cifs_shares }}"
+  with_items: "{{ pve_cifs_shares }}"
   become: true
-  when: pve__cifs_shares is defined and item.name not in pve_storage_list.stdout
+  when: pve_cifs_shares is defined and item.name not in pve__storage_status.stdout
 
 - name: Add NFS mounts
   ansible.builtin.command: /usr/sbin/pvesm add nfs {{ item.name }}
@@ -24,9 +24,9 @@
     --export {{ item.export }}
     --content {{ item.content | default("images") }}
     --nodes {{ item.nodes | default("all") }}
-  with_items: "{{ pve__nfs_mounts }}"
+  with_items: "{{ pve_nfs_mounts }}"
   become: true
-  when: pve__nfs_mounts is defined and item.name not in pve_storage_list.stdout
+  when: pve_nfs_mounts is defined and item.name not in pve__storage_status.stdout
 
 - name: Install iSCSI packages
   ansible.builtin.apt:
@@ -36,7 +36,7 @@
     state: present
     update_cache: true
   become: true
-  when: pve__iscsi_targets is defined
+  when: pve_iscsi_targets is defined
 
 - name: Set iSCSI to automatically start nodes
   ansible.builtin.lineinfile:
@@ -45,7 +45,7 @@
     line: node.startup = automatic
     insertafter: "# node.startup"
     state: present
-  when: pve__iscsi_targets is defined
+  when: pve_iscsi_targets is defined
 
 - name: Set lower replacement timeout for iSCSI multipath
   ansible.builtin.lineinfile:
@@ -53,7 +53,7 @@
     regexp: "^node.session.timeo.replacement_timeout"
     line: node.session.timeo.replacement_timeout = 15
     state: present
-  when: pve__iscsi_targets is defined
+  when: pve_iscsi_targets is defined
 
 - name: Set-up iSCSI authentication
   block:
@@ -69,7 +69,7 @@
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^discovery.sendtargets.auth.username ="
-        line: discovery.sendtargets.auth.username = {{ pve__iscsi_authentication.username }}
+        line: discovery.sendtargets.auth.username = {{ pve_iscsi_authentication.username }}
         insertafter: "#discovery.sendtargets.auth.username ="
         state: present
 
@@ -77,7 +77,7 @@
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^discovery.sendtargets.auth.password ="
-        line: discovery.sendtargets.auth.password = {{ pve__iscsi_authentication.password }}
+        line: discovery.sendtargets.auth.password = {{ pve_iscsi_authentication.password }}
         insertafter: "#discovery.sendtargets.auth.password ="
         state: present
 
@@ -85,19 +85,19 @@
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^discovery.sendtargets.auth.username_in"
-        line: discovery.sendtargets.auth.username_in = {{ pve__iscsi_authentication.username_in }}
+        line: discovery.sendtargets.auth.username_in = {{ pve_iscsi_authentication.username_in }}
         insertafter: "#discovery.sendtargets.auth.username_in"
         state: present
-      when: pve__iscsi_authentication.username_in is defined
+      when: pve_iscsi_authentication.username_in is defined
 
     - name: Configure iSCSI discovery initiator password
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^discovery.sendtargets.auth.password_in"
-        line: discovery.sendtargets.auth.password_in = {{ pve__iscsi_authentication.password_in }}
+        line: discovery.sendtargets.auth.password_in = {{ pve_iscsi_authentication.password_in }}
         insertafter: "#discovery.sendtargets.auth.password_in"
         state: present
-      when: pve__iscsi_authentication.password_in is defined
+      when: pve_iscsi_authentication.password_in is defined
 
     - name: Configure iSCSI session authentication
       ansible.builtin.lineinfile:
@@ -111,7 +111,7 @@
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^node.session.auth.username ="
-        line: node.session.auth.username = {{ pve__iscsi_authentication.username }}
+        line: node.session.auth.username = {{ pve_iscsi_authentication.username }}
         insertafter: "#node.session.auth.username ="
         state: present
 
@@ -119,7 +119,7 @@
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^node.session.auth.password ="
-        line: node.session.auth.password = {{ pve__iscsi_authentication.password }}
+        line: node.session.auth.password = {{ pve_iscsi_authentication.password }}
         insertafter: "#node.session.auth.password ="
         state: present
 
@@ -127,7 +127,7 @@
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^node.session.auth.username_in"
-        line: node.session.auth.username_in = {{ pve__iscsi_authentication.username_in }}
+        line: node.session.auth.username_in = {{ pve_iscsi_authentication.username_in }}
         insertafter: "#node.session.auth.username_in"
         state: present
 
@@ -135,7 +135,7 @@
       ansible.builtin.lineinfile:
         path: /etc/iscsi/iscsid.conf
         regexp: "^node.session.auth.password_in"
-        line: node.session.auth.password_in = {{ pve__iscsi_authentication.password_in }}
+        line: node.session.auth.password_in = {{ pve_iscsi_authentication.password_in }}
         insertafter: "#node.session.auth.password_in"
         state: present
   become: true
@@ -148,27 +148,27 @@
     --target {{ item.target }}
     --content {{ item.content | default("none") }}
     --nodes {{ item.nodes | default("all") }}
-  with_items: "{{ pve__iscsi_targets }}"
+  with_items: "{{ pve_iscsi_targets }}"
   become: true
-  when: pve__iscsi_targets is defined and item.name not in pve_storage_list.stdout
+  when: pve_iscsi_targets is defined and item.name not in pve__storage_status.stdout
 
 - name: Import ZFS pools
   ansible.builtin.command: /usr/sbin/zpool import {{ item.pool }} -f
-  with_items: "{{ pve__zfs_pools }}"
+  with_items: "{{ pve_zfs_pools }}"
   become: true
-  when: pve__zfs_pools is defined and item.name not in pve_storage_list.stdout
+  when: pve_zfs_pools is defined and item.name not in pve__storage_status.stdout
 
 - name: Add ZFS pools
   ansible.builtin.command: /usr/sbin/pvesm add zfspool {{ item.name }} -pool {{ item.pool }}
-  with_items: "{{ pve__zfs_pools }}"
+  with_items: "{{ pve_zfs_pools }}"
   become: true
-  when: pve__zfs_pools is defined and item.name not in pve_storage_list.stdout
+  when: pve_zfs_pools is defined and item.name not in pve__storage_status.stdout
 
 - name: Add LVM groups
   ansible.builtin.command: /usr/sbin/pvesm add lvm {{ item.name }}
     --vgname {{ item.vgname }}
     --content {{ item.content | default("images") }}
     --nodes {{ item.nodes | default("all") }}
-  with_items: "{{ pve__lvm_mounts }}"
+  with_items: "{{ pve_lvm_mounts }}"
   become: true
-  when: pve__lvm_mounts is defined and item.name not in pve_storage_list.stdout
+  when: pve_lvm_mounts is defined and item.name not in pve__storage_status.stdout

--- a/tasks/config-users.yaml
+++ b/tasks/config-users.yaml
@@ -1,43 +1,43 @@
 ---
-- name: Check if administrator pve group exists
+- name: Check for the existing PVE groups
   ansible.builtin.command: /usr/sbin/pveum group list
-  register: pve_group_list
+  register: pve__group_list
   check_mode: no
   changed_when: false
   become: true
 
-- name: Create administrator pve group
-  ansible.builtin.command: /usr/sbin/pveum group add {{ pve__admin_group }}
+- name: Create the Administrators PVE group
+  ansible.builtin.command: /usr/sbin/pveum group add {{ pve_admin_group }}
   become: true
-  when: pve__admin_group not in pve_group_list.stdout
+  when: pve_admin_group not in pve__group_list.stdout
 
 - name: Assign "Administrator" role to administrator group
-  ansible.builtin.command: /usr/sbin/pveum acl modify / --group {{ pve__admin_group }} --roles Administrator
+  ansible.builtin.command: /usr/sbin/pveum acl modify / --group {{ pve_admin_group }} --roles Administrator
   become: true
-  when: pve__admin_group not in pve_group_list.stdout
+  when: pve_admin_group not in pve__group_list.stdout
 
-- name: Create auditor pve group
-  ansible.builtin.command: /usr/sbin/pveum group add {{ pve__audit_group }}
+- name: Create the Auditors PVE group
+  ansible.builtin.command: /usr/sbin/pveum group add {{ pve_audit_group }}
   become: true
-  when: pve__audit_group not in pve_group_list.stdout
+  when: pve_audit_group not in pve__group_list.stdout
 
 - name: Assign "PVEAuditor" role to auditor group
-  ansible.builtin.command: /usr/sbin/pveum acl modify / --group {{ pve__audit_group }} --roles PVEAuditor
+  ansible.builtin.command: /usr/sbin/pveum acl modify / --group {{ pve_audit_group }} --roles PVEAuditor
   become: true
-  when: pve__audit_group not in pve_group_list.stdout
+  when: pve_audit_group not in pve__group_list.stdout
 
-- name: Check if the administrator pve user exist
+- name: Check for the existing PVE users
   ansible.builtin.command: /usr/sbin/pveum user list
-  register: pve_user_list
+  register: pve__user_list
   check_mode: no
   changed_when: false
   become: true
 
-- name: Create the administrator pve user and assign to the administrator group
-  ansible.builtin.command: /usr/sbin/pveum user add {{ pve__admin_user }} -password {{ pve__admin_password }} -groups {{ pve__admin_group }}
+- name: Create the administrator PVE user and assign to the Administrators group
+  ansible.builtin.command: /usr/sbin/pveum user add {{ pve_admin_user }} -password {{ pve_admin_password }} -groups {{ pve_admin_group }}
   become: true
-  when: pve__admin_password is defined and pve__admin_user not in pve_user_list.stdout
+  when: pve_admin_password is defined and pve_admin_user not in pve__user_list.stdout
 
-- name: Create the auditor pve user and assign to the auditor group
-  ansible.builtin.command: /usr/sbin/pveum user add {{ pve__audit_user }} -password {{ pve__audit_password }} -groups {{ pve__audit_group }}
-  when: pve__audit_password is defined and pve__audit_user not in pve_user_list.stdout
+- name: Create the auditor PVE user and assign to the Auditors group
+  ansible.builtin.command: /usr/sbin/pveum user add {{ pve_audit_user }} -password {{ pve_audit_password }} -groups {{ pve_audit_group }}
+  when: pve__audit_password is defined and pve__audit_user not in pve__user_list.stdout

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -6,11 +6,11 @@
 
 - name: Configure networking
   ansible.builtin.include_tasks: config-network.yaml
-  when: pve__network_interfaces is defined and pve__network_bridges is defined
+  when: pve_network_interfaces is defined and pve_network_bridges is defined
 
 - name: Configure IOMMU
   ansible.builtin.include_tasks: enable-iommu.yaml
-  when: pve__iommu_arch is defined
+  when: pve_iommu_arch is defined
 
 - name: Configure Proxmox VE repositories and packages
   ansible.builtin.include_tasks: config-pve-repos.yaml
@@ -35,12 +35,12 @@
   ansible.builtin.lineinfile:
     path: /etc/pve/datacenter.cfg
     regexp: "^tag-style:"
-    line: "tag-style: case-sensitive=1,ordering={{ pve__datacenter_tag_style_order }}"
+    line: "tag-style: case-sensitive=1,ordering={{ pve_datacenter_tag_style_order }}"
     state: present
-  when: pve__datacenter_tag_style_order is defined
+  when: pve_datacenter_tag_style_order is defined
 
 - name: Force host reboot
   ansible.builtin.debug:
-    msg: "pve__force_reboot was set to true. Rebooting the host"
+    msg: "pve_force_reboot was set to true. Rebooting the host"
   notify: Reboot host
-  when: pve__force_reboot
+  when: pve_force_reboot

--- a/templates/grub.j2
+++ b/templates/grub.j2
@@ -6,7 +6,7 @@
 GRUB_DEFAULT=0
 GRUB_TIMEOUT=2
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet {{ pve__iommu_arch }}_iommu=on {% if pve__iommu_passthrough %}iommu=pt{% endif %}"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet {{ pve_iommu_arch }}_iommu=on {% if pve_iommu_passthrough %}iommu=pt{% endif %}"
 GRUB_CMDLINE_LINUX=""
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -5,7 +5,7 @@
 auto lo
 iface lo inet loopback
 
-{% for interface in pve__network_interfaces %}
+{% for interface in pve_network_interfaces %}
 {% if interface is string %}
 iface {{ interface }} inet manual
 {% else %}
@@ -31,7 +31,7 @@ iface {{ interface.name }} inet manual
 {% endif %}
 
 {% endfor %}
-{% for bridge in pve__network_bridges %}
+{% for bridge in pve_network_bridges %}
 auto {{ bridge.name }}
 {% if bridge.address is defined %}
 iface {{ bridge.name }} inet static


### PR DESCRIPTION
Use the more common variable naming convention, after this commit the variable meaning changed to:

- Variables starting with `pve_` (single underscore) are considered public variables, defined for user configurations.
- Variables starting with `pve__` (double underscore) are considered private variables, defined for internal usage only.

Also, give a better name for some tasks.