### PR TITLE
Convert role to ansible-galaxy format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
-Copyright (R) 2020 Filipe Utzig <filipeutzig@gmail.com>
-
 ----------------------------------------------------------------------------
 "THE BEER-WARE LICENSE" (Revision 42):
-<filipeutzig@gmail.com> wrote this file. As long as you retain this notice
+<filipe@gringolito.com> wrote this file. As long as you retain this notice
 you can do whatever you want with this stuff. If we meet some day, and you
 think this stuff is worth it, you can buy me a beer in return. Filipe Utzig.
 ----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,2 +1,183 @@
 # ansible-proxmox-ve
-Ansible playbook for provisioning a Proxmox VE server
+Ansible role for configuring a Proxmox VE server/cluster.
+
+## Requirements
+
+This role assumes that you are running it on Proxmox server installation.
+
+### Cluster joining
+
+For nodes to join on a existing cluster, the current node and existing member should have SSH
+connection with SSH keys setup.
+
+## Role Variables
+
+### General configurations
+
+| Variable | Comment |
+| -------- | ------- |
+| **pve_force_reboot**<br>*boolean* | <p>Force the server to reboot after executing the role.<p>**Choices:**<br>- `true`<br>- `false` &larr; (default) |
+| **pve_force_reboot**<br>*boolean* | <p>Force the server to reboot after executing the role.<p>**Choices:**<br>- `true`<br>- `false` &larr; (default) |
+| **pve_enterprise**<br>*boolean* | <p>Defines whether the server has an PVE-Enterprise license.<p>**Choices:**<br>- `true`<br>- `false` &larr; (default) |
+| **pve_datacenter_tag_style_order**<br>*string* | <p>Defines the order of the guests tags. Set to `config` to respect the configuration order. Alphabetical order will be used otherwise. |
+
+### PCI passthrough (IOMMU) configurations
+
+| Variable | Comment |
+| -------- | ------- |
+| **pve_iommu_passthrough**<br>*boolean* | <p>Enable/disable PCI passthrough configuration.<p>**Choices:**<br>- `true`<br>- `false` &larr; (default) |
+| **pve_iommu_intel**<br>*boolean* | <p>Enable/disable the IOMMU for Intel processors with VT-d/VT-x.<p>**Choices:**<br>- `true`<br>- `false` &larr; (default) |
+
+### PVE users/groups configurations
+
+| Variable | Comment |
+| -------- | ------- |
+| **pve_admin_group**<br>*string* | <p>Define the Administrators group on the PVE realm.<p>**Default:** `Administrators` |
+| **pve_admin_user**<br>*string* | <p>Define the administrator user on the PVE realm.<p>**Default:** `admin@pve` |
+| **pve_audit_group**<br>*string* | <p>Define the Auditors group on the PVE realm.<p>**Default:** `Auditors` |
+| **pve_audit_user**<br>*string* | <p>Define the audit user on the PVE realm.<p>**Default:** `audit@pve` |
+
+### PVE cluster configurations
+
+| Variable | Comment |
+| -------- | ------- |
+| **pve_cluster_create**<br>*string* | <p>Define the name of PVE cluster to be created.<p>This variable MUST be defined in only one node per cluster. |
+| **pve_cluster_hostname**<br>*string* | <p>Define the node hostname.<p>**Default:** `{{ ansible_hostname }}` |
+| **pve_cluster_join_address**<br>*string* | <p>Define the address of an existing cluster member to join.<p>**Format:** DNS-like name, IP address or IPv6 address. |
+| **pve_cluster_link**<br>*string* | <p>Force the cluster communication to go through the specified link address.<p>**Format:** DNS-like name, IP address or IPv6 address. |
+| **pve_cluster_ha_shutdown_policy**<br>*string* | <p>Define the shutdown policy for HA-enabled guests.<p>Please refer to the **Shutdown Policy** section on the official Proxmox [High Availability](https://pve.proxmox.com/wiki/High_Availability#ha_manager_node_maintenance) guide for more information.<p>**Choices:**<br>- `freeze`<br>- `failover`<br>- `migrate`<br>- `conditional` |
+| **pve_cluster_migration_network**<br>*string* | <p>Set the network for running guests migration.<p>**Format:** IP address/mask or IPv6 address/mask. |
+
+### PVE local network configurations
+
+| Variable | Comment |
+| -------- | ------- |
+| **pve_network_interfaces**<br>*list / elements=string or [interface_config](#interface_config-attributes)* | <p>Defines the local network interfaces configuration. |
+| **pve_network_bridges**<br>*list / elements=[bridge_config](#bridge_config-attributes)* | <p>Defines the local network bridges configuration. |
+| **pve_network_interface_alias**<br>*list / elements=[interface_alias](#interface_alias-attributes)* | <p>Defines persistent interface alias for local network interfaces. Use this to rename interface to a more convenient names. |
+
+#### interface_config Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **name**<br>*string* | <p>The interface name.<p>For VLAN tagged interfaces append the VLAN tag on the interface name (e.g: `eno1.10`).<p>Informing only the `name` attribute is the same as informing a plain `string`. | Required |
+| **allow**<br>*string* | <p>Identify the subsystem that should brought up the interface.<p>**Choices:**<br>- `hotplug` | Optional |
+| **address**<br>*string* | <p>The address to be assigned to the interface.<p>**Format:** IP address/mask. | Optional |
+| **gateway**<br>*string* | <p>The network gateway address.<p>**Format:** IP address. | Optional |
+| **description**<br>*string* | <p>Free-form comment to be appended on the interface configuration. | Optional |
+
+#### bridge_config Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **name**<br>*string* | <p>The bridge name. | Required |
+| **interfaces**<br>*string*<br>*list / elements=string* | <p>The physical interface(s) that should be bridged into. | Required |
+| **address**<br>*string* | <p>The address to be assigned to the brigde.<p>**Format:** IP address/mask. | Optional |
+| **gateway**<br>*string* | <p>The network gateway address.<p>**Format:** IP address. | Optional |
+| **vlans**<br>*string* | <p>Turn the bridge into a VLAN-aware bridge for the configured VLANs.<p>**Format:** comma separated list of VLAN ID, range of VLAN IDs can be grouped with dashes (e.g. `2-1000,2000`). | Optional |
+| **description**<br>*string* | <p>Free-form comment to be appended on the interface configuration. | Optional |
+
+#### interface_alias Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **mac_address**<br>*string* | <p>The MAC address to match the interface.<p>At least one in `mac_address` or `driver` MUST be defined. | Optional |
+| **driver**<br>*string* | <p>The driver to match the interface.<p>To discover your interface driver you can run:<br>`# ethtool -i {interface_name}`<p>At least one in `mac_address` or `driver` MUST be defined. | Optional |
+| **interface_name**<br>*string* | <p>The name (*alias*) to be configured for the interface. | Required |
+
+### PVE storage configurations
+
+| Variable | Comment |
+| -------- | ------- |
+| **pve_cifs_shares**<br>*list / elements=[cifs_share](#cifs_share-attributes)* | <p>Define the CIFS/SMB shares to be added on the server/cluster storage. |
+| **pve_nfs_mounts**<br>*list / elements=[nfs_mount](#nfs_mount-attributes)* | <p>Define the NFS mounts to be added on the server/cluster storage. |
+| **pve_iscsi_targets**<br>*list / elements=[iscsi_target](#iscsi_target-attributes)* | <p>Define the iSCSI targets to be added on the server/cluster storage. |
+| **pve_iscsi_authentication**<br>*[iscsi_authentication](#iscsi_authentication-attributes)* | <p>Define the iSCSI authentication for the iSCSI targets, whenever authentication is needed. |
+| **pve_zfs_pools**<br>*list / elements=[zfs_pool](#zfs_pool-attributes)* | <p>Defined the ZFS pools to be added on the server/cluster storage. |
+| **pve_lvm_mounts**<br>*list / elements=[lvm_mount](#lvm_mount-attributes)* | <p>Define the LVM mounts to be added on the server/cluster storage. |
+
+#### cifs_share Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **name**<br>*string* | <p>The storage name on the Proxmox server/cluster. | Required |
+| **server**<br>*string* | <p>The CIFS/SMB server address.<p>**Format:** DNS-like name, IP address or IPv6 address. | Required |
+| **share**<br>*string* | <p>The CIFS/SMB share name. | Required |
+| **username**<br>*string* | <p>The CIFS/SMB username credentials. | Required |
+| **password**<br>*string* | <p>The CIFS/SMB password credentials. | Required |
+| **content**<br>*string* | <p>Comma separated list of the storage content types.<p>Please refer to the **Common Storage Properties** section on the official Proxmox [Storage](https://pve.proxmox.com/pve-docs/chapter-pvesm.html#_common_storage_properties) documentation for more information.<p>**Choices:**<br>- `images` &larr; (default)<br>- `rootdir`<br>- `vztmpl`<br>- `backup`<br>- `iso`<br>- `snippets` | Optional |
+| **shared**<br>*boolean* | <p>Indicate that this is a single storage with the same contents on all nodes.<p>**Choices:**<br>- `true` &larr; (default)<br>- `false` | Optional |
+
+#### nfs_mount Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **name**<br>*string* | <p>The storage name on the Proxmox server/cluster. | Required |
+| **server**<br>*string* | <p>The NFS server address.<p>**Format:** DNS-like name, IP address or IPv6 address. | Required |
+| **export**<br>*path* | <p>The NFS export path. | Required |
+| **content**<br>*string* | <p>Comma separated list of the storage content types.<p>Please refer to the **Common Storage Properties** section on the official Proxmox [Storage](https://pve.proxmox.com/pve-docs/chapter-pvesm.html#_common_storage_properties) documentation for more information.<p>**Choices:**<br>- `images` &larr; (default)<br>- `rootdir`<br>- `vztmpl`<br>- `backup`<br>- `iso`<br>- `snippets` | Optional |
+| **nodes**<br>*string* | <p>Comma separated list of nodes where the should be available, set `all` for all nodes on the cluster.<p>**Default:** `all` | Optional |
+
+#### iscsi_target Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **name**<br>*string* | <p>The storage name on the Proxmox server/cluster. | Required |
+| **portal**<br>*string* | <p>The iSCSI server address.<p>**Format:** DNS-like name, IP address or IPv6 address. | Required |
+| **target**<br>*path* | <p>The iSCSI target IQN.<p>**Format:** base-name:target| Required |
+| **content**<br>*string* | <p>The iSCSI storage content types.<p>If you want to use LVM on top of iSCSI, it make sense to set content `none`. That way it is not possible to create VMs using iSCSI LUNs directly.<p>Please refer to the **Common Storage Properties** section on the official Proxmox [Storage](https://pve.proxmox.com/pve-docs/chapter-pvesm.html#_common_storage_properties) documentation for more information.<p>**Choices:**<br>- `images`<br>- `none` &larr; (default) | Optional |
+| **nodes**<br>*string* | <p>Comma separated list of nodes where the should be available, set `all` for all nodes on the cluster.<p>**Default:** `all` | Optional |
+
+#### iscsi_authentication Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **username**<br>*string* | <p>The iSCSI User credentials. | Required |
+| **password**<br>*string* | <p>The iSCSI User secret credentials. | Required |
+| **username_in**<br>*string* | <p>The iSCSI Peer (*initiator*) User credentials. | Required |
+| **password_in**<br>*string* | <p>The iSCSI Peer (*initiator*) secret credentials. | Required |
+
+#### zfs_pool Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **name**<br>*string* | <p>The storage name on the Proxmox server/cluster. | Required |
+| **pool**<br>*string* | <p>The ZFS pool name. | Required |
+| **content**<br>*string* | <p>Comma separated list of the storage content types.<p>Please refer to the **Common Storage Properties** section on the official Proxmox [Storage](https://pve.proxmox.com/pve-docs/chapter-pvesm.html#_common_storage_properties) documentation for more information.<p>**Choices:**<br>- `images` &larr; (default)<br>- `rootdir`<br> | Optional |
+
+#### lvm_mount Attributes
+
+| Attribute | Comment | Required / Optional |
+| --------- | ------- | ------------------- |
+| **name**<br>*string* | <p>The storage name on the Proxmox server/cluster. | Required |
+| **vgname**<br>*string* | <p>LVM volume group name. This must point to an existing volume group. | Required |
+| **content**<br>*string* | <p>Comma separated list of the storage content types.<p>Please refer to the **Common Storage Properties** section on the official Proxmox [Storage](https://pve.proxmox.com/pve-docs/chapter-pvesm.html#_common_storage_properties) documentation for more information.<p>**Choices:**<br>- `images` &larr; (default)<br>- `rootdir`<br> | Optional |
+
+## Example Playbook
+
+```yaml
+  - name: Configuring Proxmox VE server
+    hosts: all
+    roles:
+      - gringolito.proxmox_ve
+    vars:
+      pve_datacenter_tag_style_order: config
+      pve_iommu_intel: true
+      pve_iommu_passthrough: true
+      pve_network_interface_alias:
+        - driver: r8152
+          interface_name: enusb0
+      pve_nfs_mounts:
+        - name: my-nfs
+          server: nfs.gringolito.com
+          export: /mnt/nfs/pve
+          content: images,backup,iso
+```
+
+## License
+
+Beerware
+
+## Author Information
+
+Filipe Utzig < filipe at gringolito.com >

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,7 +2,9 @@
 pve_force_reboot: false
 pve_enterprise: false
 pve_iommu_passthrough: false
+pve_iommu_intel: false
 pve_admin_group: Administrators
 pve_admin_user: admin@pve
 pve_audit_group: Auditors
 pve_audit_user: audit@pve
+pve_cluster_hostname: "{{ ansible_hostname }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,23 @@
+galaxy_info:
+  author: Filipe Utzig
+  description: Configure a Proxmox VE server or cluster
+  namespace: gringolito
+  role_name: proxmox_ve
+  standalone: true
+  license: Beerware
+  min_ansible_version: "2.14"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - bullseye
+
+  galaxy_tags:
+    - proxmox
+    - virtualization
+    - cluster
+    - pve
+    - kvm
+
+dependencies: []

--- a/tasks/config-cluster.yaml
+++ b/tasks/config-cluster.yaml
@@ -6,18 +6,18 @@
   changed_when: false
   ignore_errors: true
   become: true
-  when: pve_cluster_master is defined
+  when: pve_cluster_create is defined
 
 - name: Create Proxmox cluster
   become: true
-  when: pve_cluster_master is defined and pve_cluster_master not in pve__cluster_status.stdout
+  when: pve_cluster_create is defined and pve_cluster_create not in pve__cluster_status.stdout
   block:
     - name: Create cluster (auto link discover)
-      ansible.builtin.command: /usr/bin/pvecm create {{ pve_cluster_master }}
+      ansible.builtin.command: /usr/bin/pvecm create {{ pve_cluster_create }}
       when: pve_cluster_link is not defined
 
     - name: Create cluster (manual link0)
-      ansible.builtin.command: /usr/bin/pvecm create {{ pve_cluster_master }} --link0 {{ pve_cluster_link }}
+      ansible.builtin.command: /usr/bin/pvecm create {{ pve_cluster_create }} --link0 {{ pve_cluster_link }}
       when: pve_cluster_link is defined
 
 - name: Verify cluster membership
@@ -28,18 +28,18 @@
   changed_when: false
   ignore_errors: true
   become: true
-  when: pve_cluster_join is defined
+  when: pve_cluster_join_address is defined
 
 - name: Add Proxmox node to the cluster
   become: true
-  when: pve_cluster_join is defined and (pve__cluster_nodes.rc == 2 or pve_cluster_node not in pve__cluster_nodes.stdout)
+  when: pve_cluster_join_address is defined and (pve__cluster_nodes.rc == 2 or pve_cluster_hostname not in pve__cluster_nodes.stdout)
   block:
     - name: Add node using (auto link discover)
-      ansible.builtin.command: /usr/bin/pvecm add {{ pve_cluster_join }} --use_ssh
+      ansible.builtin.command: /usr/bin/pvecm add {{ pve_cluster_join_address }} --use_ssh
       when: pve_cluster_link is not defined
 
     - name: Add node to the cluster (manual link0)
-      ansible.builtin.command: /usr/bin/pvecm add {{ pve_cluster_join }} --link0 {{ pve_cluster_link }} --use_ssh
+      ansible.builtin.command: /usr/bin/pvecm add {{ pve_cluster_join_address }} --link0 {{ pve_cluster_link }} --use_ssh
       when: pve_cluster_link is defined
 
 - name: Configure HA shutdown policy

--- a/tasks/config-network.yaml
+++ b/tasks/config-network.yaml
@@ -9,7 +9,6 @@
     mode: 0644
   become: true
   notify: Restart network interfaces
-# check network configuration template
 
 - name: Configure network interface names
   ansible.builtin.template:
@@ -23,4 +22,3 @@
   when: pve_network_interface_alias is defined
   become: true
   notify: Reboot host
-# check interface name template

--- a/tasks/config-storage.yaml
+++ b/tasks/config-storage.yaml
@@ -6,7 +6,7 @@
   changed_when: false
   become: true
 
-- name: Add SMB shares
+- name: Add CIFS/SMB shares
   ansible.builtin.command: /usr/sbin/pvesm add cifs {{ item.name }}
     --server {{ item.server }}
     --share {{ item.share }}
@@ -56,6 +56,9 @@
   when: pve_iscsi_targets is defined
 
 - name: Set-up iSCSI authentication
+  become: true
+  notify: Restart iSCSI
+  when: pve_iscsi_authentication is defined
   block:
     - name: Configure iSCSI discovery authentication method
       ansible.builtin.lineinfile:
@@ -138,9 +141,6 @@
         line: node.session.auth.password_in = {{ pve_iscsi_authentication.password_in }}
         insertafter: "#node.session.auth.password_in"
         state: present
-  become: true
-  notify: Restart iSCSI
-  when: pve__iscsi_authentication is defined
 
 - name: Add iSCSI mounts
   ansible.builtin.command: /usr/sbin/pvesm add iscsi {{ item.name }}
@@ -159,7 +159,9 @@
   when: pve_zfs_pools is defined and item.name not in pve__storage_status.stdout
 
 - name: Add ZFS pools
-  ansible.builtin.command: /usr/sbin/pvesm add zfspool {{ item.name }} -pool {{ item.pool }}
+  ansible.builtin.command: /usr/sbin/pvesm add zfspool {{ item.name }}
+    --pool {{ item.pool }}
+    --content {{ item.content | default("images") }}
   with_items: "{{ pve_zfs_pools }}"
   become: true
   when: pve_zfs_pools is defined and item.name not in pve__storage_status.stdout
@@ -168,7 +170,6 @@
   ansible.builtin.command: /usr/sbin/pvesm add lvm {{ item.name }}
     --vgname {{ item.vgname }}
     --content {{ item.content | default("images") }}
-    --nodes {{ item.nodes | default("all") }}
   with_items: "{{ pve_lvm_mounts }}"
   become: true
   when: pve_lvm_mounts is defined and item.name not in pve__storage_status.stdout

--- a/tasks/config-users.yaml
+++ b/tasks/config-users.yaml
@@ -40,4 +40,5 @@
 
 - name: Create the auditor PVE user and assign to the Auditors group
   ansible.builtin.command: /usr/sbin/pveum user add {{ pve_audit_user }} -password {{ pve_audit_password }} -groups {{ pve_audit_group }}
+  become: true
   when: pve__audit_password is defined and pve__audit_user not in pve__user_list.stdout

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -15,14 +15,14 @@
 - name: Configure Proxmox VE repositories and packages
   ansible.builtin.include_tasks: config-pve-repos.yaml
 
+- name: Configure PVE Cluster
+  ansible.builtin.include_tasks: config-cluster.yaml
+
 - name: Configure PVE Users and Groups
   ansible.builtin.include_tasks: config-users.yaml
 
 - name: Configure PVE Storage
   ansible.builtin.include_tasks: config-storage.yaml
-
-- name: Configure PVE Cluster
-  ansible.builtin.include_tasks: config-cluster.yaml
 
 - name: Install Proxmox VE kernel headers
   ansible.builtin.apt:

--- a/templates/grub.j2
+++ b/templates/grub.j2
@@ -6,7 +6,7 @@
 GRUB_DEFAULT=0
 GRUB_TIMEOUT=2
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet {{ pve_iommu_arch }}_iommu=on {% if pve_iommu_passthrough %}iommu=pt{% endif %}"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet{% if pve_iommu_intel %} intel_iommu=on{% endif %}{% if pve_iommu_passthrough %} iommu=pt{% endif %}"
 GRUB_CMDLINE_LINUX=""
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -7,16 +7,14 @@ iface lo inet loopback
 
 {% for interface in pve_network_interfaces %}
 {% if interface is string %}
+auto {{ interface }}
 iface {{ interface }} inet manual
 {% else %}
-{% if interface.auto is defined and interface.auto %}
 auto {{ interface.name }}
-{% endif %}
 {% if interface.allow is defined %}
 allow-{{ interface.allow }} {{ interface.name }}
 {% endif %}
 {% if interface.address is defined %}
-auto {{ interface.name }}
 iface {{ interface.name }} inet static
   address {{ interface.address }}
 {% if interface.gateway is defined %}
@@ -42,7 +40,11 @@ iface {{ bridge.name }} inet static
 {% else %}
 iface {{ bridge.name }} inet manual
 {% endif %}
+{% if bridge.interfaces is list %}
+  bridge_ports {{ " ".joing(bridge.interfaces) }}
+{% else %}
   bridge_ports {{ bridge.interfaces }}
+{% endif %}
   bridge_stp off
   bridge_fd 0
 {% if bridge.vlans is defined %}

--- a/templates/link.j2
+++ b/templates/link.j2
@@ -1,7 +1,8 @@
 [Match]
 {% if item.mac_address is defined %}
 MACAddress={{ item.mac_address }}
-{% elif item.driver is defined %}
+{% endif %}
+{% if item.driver is defined %}
 Driver={{ item.driver }}
 {% endif %}
 


### PR DESCRIPTION
Added the required information to make the role compatible with ansible-galaxy distribution format.

Also, to make it properly usable the role documentation was added on the README file of the project. While writing the documentation some variable names have change to better describe their intents.